### PR TITLE
add case by activty and by resource

### DIFF
--- a/core/app_utils/mappings.py
+++ b/core/app_utils/mappings.py
@@ -31,6 +31,24 @@ DOTS_COLOR_MAP = {
 # View Configuration Presets
 # Pattern support: Gap, Burst, Outlier, Cluster, Sequence
 VIEW_PRESETS = {
+    "Case by Activity": {
+        "x_axis": "Actual time",
+        "y_axis": "Case ID",
+        "color": "Activity",
+        "description": "What activities are performed in each case?",
+        "axes_info": "X: Time | Y: Case ID | Color: Activity",
+        "patterns": ["Gap", "Outlier", "Sequence"],
+        "pattern_score": "3/5"
+    },
+    "Case by Resource": {
+        "x_axis": "Actual time",
+        "y_axis": "Case ID",
+        "color": "Resource",
+        "description": "Which resources are used by each case?",
+        "axes_info": "X: Time | Y: Case ID | Color: Resource",
+        "patterns": ["Gap", "Outlier", "Sequence"],
+        "pattern_score": "3/5"
+    },
     "Resource Timeline": {
         "x_axis": "Actual time",
         "y_axis": "Resource",


### PR DESCRIPTION
added new defaults: Case by Activity and Case by Resource.

Case by Activity is the one that is standardly used i think because there we actually look at the variants/traces. 


Thats also the ones we actually mean in our presentation slides if i am not mistaken:
<img width="768" height="176" alt="image" src="https://github.com/user-attachments/assets/44c2d1b2-2f65-4fb7-8f8e-f5bb92b6ea36" />
