### PR TITLE
Remove Praktikum reference from app header

### DIFF
--- a/app.py
+++ b/app.py
@@ -73,7 +73,7 @@ def main():
         <div class="main-header">
             <h1>Visual Pattern Detection in Dotted Charts</h1>
             <p class="main-subtitle">
-                Process Mining Praktikum WS 25/26 · LMU München ·
+                LMU München ·
                 Tan Tai Bui, Jennifer Nikolovic, Anna Tsaan
             </p>
         </div>


### PR DESCRIPTION
Removes the "Process Mining Praktikum WS 25/26" reference from the app header subtitle in `app.py`, matching the changes already made to the README and the GitHub About section for the SoftwareX submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)